### PR TITLE
Organized

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ __pycache__/*
 *.pyc
 _data/*
 figure/*
+*.csv
+report.md
+.idea

--- a/_config/dirs.txt
+++ b/_config/dirs.txt
@@ -1,2 +1,2 @@
-/rfanfs/pnl-zorro
+/rfanfs/pnl-zorro/
 tb571@eris1n2.research.partners.org:/data/pnl

--- a/dir_sort.py
+++ b/dir_sort.py
@@ -5,8 +5,12 @@ import sys
 from os.path import isdir
 
 def usage():
-    print('Usage:  ./dir_sort.py infoFile.csv outSummary.csv `ls -d /abs/path/of/parent/dir/*/`\n'
-          '\t./dir_sort.py infoFile.csv outSummary.csv `ls -d /abs/path/of/parent/dir/*`')
+    print('''Usage:  
+# for all subdirectories in dir
+./dir_sort.py infoFile.csv outSummary.csv `ls -d /abs/path/of/parent/dir/*/`
+# for all files in dir`
+./dir_sort.py infoFile.csv outSummary.csv `ls -d /abs/path/of/parent/dir/*`''')
+
     exit()
 
 def main():

--- a/generatesummary.sh
+++ b/generatesummary.sh
@@ -50,7 +50,10 @@ do
     else
         remote=true
     fi
-    
+
+    # remove trailing slash from directory name
+    directory=${directory%/}
+
     logfile=$(logfilename $directory $depth)
 
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+Rscript -e "pkgs <-c('ggplot2', 'data.table', 'xtable', 'magrittr', 'lubridate', 'bit64', 'knitr');for(p in pkgs) install.packages(p); warnings()"

--- a/report-lib/report.Rmd
+++ b/report-lib/report.Rmd
@@ -15,7 +15,7 @@ ggplot(df, aes(x=date, y=UsageT)) +
     geom_line(aes(color=Filesystem), na.rm=T) +
     ggtitle("Filesystem Usage (Terabytes)") +
     geom_text(data=df.mostRecent, aes(label=UsageT, color=Filesystem),  hjust = 0.9, vjust = -0.6, na.rm=T, size=7) +
-    ylim(0,150) +
+    ylim(0,200) +
     theme(text = element_text(size=20))
 
 ```
@@ -29,7 +29,7 @@ dirsizes[,Date:= format(date,format="%y-%m-%d")]
 setorder(dirsizes, -date)
 cols <- c("Date", "Directory", "SizeG", "deltaG")
 
-for (numPeriods in c(1,4,8,12)) {
+for (numPeriods in c(1,4)) {
   ## cat("# Directory Size Changes (", numPeriods, " Periods)\n", sep="")
   for (rootDir in readLines("../_config/dirs.txt", encoding="UTF-8")) {
     rootDir <- stripHost(rootDir)


### PR DESCRIPTION
1. BACKWARD COMPATIBILITY: keep trailing slash for pnl-zorro, otherwise it causes trouble with 
categorized report generation
2. Increase ylim to 200 TB
3. Decrease period to 4 weeks
4. Update gitignore with data files to repo is easier to track